### PR TITLE
Allow the use of cursors in Solr searches

### DIFF
--- a/ckanext/datasolr/lib/solr_search.py
+++ b/ckanext/datasolr/lib/solr_search.py
@@ -107,7 +107,13 @@ class SolrSearch(object):
             fields=fields,
             total=total,
             records=search.results,
+            # indicates that this response came from Solr, this is used by the ckanpackager
+            _backend='datasolr',
         )
+
+        # if there is a next cursor mark in the Solr response, pass it on
+        if hasattr(search, 'nextCursorMark'):
+            response['next_cursor'] = search.nextCursorMark
 
         requested_fields = [f['id'] for f in fields]
         # Date fields are returned as python datetime objects
@@ -161,6 +167,10 @@ class SolrSearch(object):
             solr_params['group'] = 'true'
             solr_params['group_field'] = fields
             solr_params['group_main'] = 'true'
+        # add cursor
+        cursor = params.get('cursor', None)
+        if cursor:
+            solr_params['cursorMark'] = cursor
 
         # Add facets
         facets = params.get('facets', [])

--- a/ckanext/datasolr/plugin.py
+++ b/ckanext/datasolr/plugin.py
@@ -95,14 +95,15 @@ class DataSolrPlugin(p.SingletonPlugin):
             facets_field_limit=data_dict.get('facets_field_limit'),
             limit=data_dict.get('limit', 100),
             sort=data_dict.get('sort'),
-            distinct=data_dict.get('distinct', False)
+            distinct=data_dict.get('distinct', False),
+            cursor=data_dict.get('cursor', None),
         )
         query_params['fields'] = data_dict.get('fields', [f['id'] for f in fields])
         cursor = data_dict.get('cursor', None)
         if cursor:
             # Must be sorted on primary key
             # TODO: We could get the primary field from the solr schema lookup
-            query_params['sort'] = [('_id', 'ASC')]
+            query_params['sort'] = '_id'
         else:
             # If we've specified a paging cursor, then we don't want to use the offset
             query_params['offset'] = data_dict.get('offset', 0)


### PR DESCRIPTION
The ckanpackager uses cursors for Solr searches if they are available, this ensures it does not receive any duplicate entries. This feature was not supported in this extension however. This commit fixes that issue by allowing cursor usage and ensuring the correct information is passed back in responses.

See https://github.com/NaturalHistoryMuseum/ckanpackager/blob/master/ckanpackager/tasks/datastore_package_task.py#L75 and https://github.com/NaturalHistoryMuseum/ckanpackager/blob/master/ckanpackager/tasks/datastore_package_task.py#L91

Due to the way cursors in Solr work, I also believe that this will work with separate load balanced servers, however this needs to be confirmed. Until this is confirmed, only one Solr server should be in the load balancer.

Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/166